### PR TITLE
Fix the Flatpak External Data Checker configuration

### DIFF
--- a/org.freedesktop.Sdk.Extension.ziglang.json
+++ b/org.freedesktop.Sdk.Extension.ziglang.json
@@ -27,7 +27,7 @@
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://ziglang.org",
-                        "version-pattern": "Latest Release: &nbsp; <b>(\\d+\\.\\d+\\.\\d+)</b>",
+                        "version-pattern": "Latest Release:\n               &nbsp;<span>(\\d+\\.\\d+\\.\\d+)</span>",
                         "url-template": "https://ziglang.org/download/$version/zig-linux-x86_64-$version.tar.xz"
                     },
                     "only-arches": [
@@ -41,7 +41,7 @@
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://ziglang.org",
-                        "version-pattern": "Latest Release: &nbsp; <b>(\\d+\\.\\d+\\.\\d+)</b>",
+                        "version-pattern": "Latest Release:\n               &nbsp;<span>(\\d+\\.\\d+\\.\\d+)</span>",
                         "url-template": "https://ziglang.org/download/$version/zig-linux-aarch64-$version.tar.xz"
                     },
                     "only-arches": [


### PR DESCRIPTION
Additionally Flatpak External Data Checker can made to run on multiple branches instead of running on the default branch only, according to [this page](https://docs.flathub.org/docs/for-app-authors/external-data-checker#run-on-multiple-branches), but that would require applying this commit to other branches too.